### PR TITLE
Fix code scanning alert no. 31: Clear-text logging of sensitive information

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -41,7 +41,7 @@ const User = require('../models/user'); // Adjust the path as needed
 
 passport.use(new LocalStrategy(async (email, password, done) => {
     try {
-        console.log('Received credentials:', email, password);
+        console.log('Received credentials for email:', email);
         const user = await User.findOne({ email });
         if (!user)
             return done(null, false, { message: 'Incorrect email.' });


### PR DESCRIPTION
Fixes [https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/31](https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/31)

To fix the problem, we need to remove the logging of sensitive information such as passwords. Instead of logging the password, we can log a message indicating that credentials were received without including the sensitive data. This way, we maintain the ability to debug without exposing sensitive information.

- Remove the logging of the password on line 44.
- Log a generic message indicating that credentials were received.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
