### PR TITLE
Fix code scanning alert no. 30: Missing rate limiting

### DIFF
--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -4,7 +4,8 @@ const User = require('../models/user');
 const { jwtAuthMiddleware, generateToken } = require('../middleware/jwt');
 const multer = require('multer');
 const path = require('path');
-const fs=require('fs');
+const fs = require('fs');
+const rateLimit = require('express-rate-limit');
 
 const storage = multer.diskStorage({
     destination: './uploads/',
@@ -18,6 +19,12 @@ const upload = multer({ storage ,
   fileFilter: (req, file, cb) => {
     checkFileType(file, cb);
   }
+});
+
+const updateProfileLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: 'Too many requests, please try again later.'
 });
 
 function checkFileType(file, cb) {
@@ -59,7 +66,7 @@ router.get('/form', jwtAuthMiddleware, async (req, res) => {
 
 
 
-router.post('/update-profile', jwtAuthMiddleware, upload.single('profilePicture'), async (req, res) => {
+router.post('/update-profile', jwtAuthMiddleware, updateProfileLimiter, upload.single('profilePicture'), async (req, res) => {
     try {
       let email;
       if (req.user.email) {


### PR DESCRIPTION
Fixes [https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/30](https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/30)

To fix the problem, we will introduce rate limiting to the route handler that performs the database access. We will use the `express-rate-limit` package to limit the number of requests a user can make to the `/update-profile` endpoint within a specified time window. This will help prevent abuse and mitigate the risk of DoS attacks.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `src/routes/user.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the `/update-profile` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
