### PR TITLE
Fix code scanning alert no. 21: Missing rate limiting

### DIFF
--- a/src/routes/batch.js
+++ b/src/routes/batch.js
@@ -2,9 +2,14 @@ const express = require('express');
 const router = express.Router();
 const User = require('../models/user');
 const { jwtAuthMiddleware } = require('../middleware/jwt');
+const rateLimit = require('express-rate-limit');
 
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
 
-router.get('/batch', jwtAuthMiddleware, async (req, res) => {
+router.get('/batch', limiter, jwtAuthMiddleware, async (req, res) => {
   try {
     const users = await User.find().sort('email');
     const userjwt=req.cookies.jwt ;
@@ -16,7 +21,7 @@ router.get('/batch', jwtAuthMiddleware, async (req, res) => {
     res.status(500).json({ error: 'Internal Server Error' });
   }
 });
-router.get('/batch2027', jwtAuthMiddleware, async (req, res) => {
+router.get('/batch2027', limiter, jwtAuthMiddleware, async (req, res) => {
   try {
     const users = await User.find().sort('email');
     const userjwt=req.cookies.jwt ;
@@ -27,7 +32,7 @@ router.get('/batch2027', jwtAuthMiddleware, async (req, res) => {
     res.status(500).json({ error: 'Internal Server Error' });
   }
 });
-router.get('/batch2028', jwtAuthMiddleware, async (req, res) => {
+router.get('/batch2028', limiter, jwtAuthMiddleware, async (req, res) => {
   try {
     const users = await User.find().sort('email');
     const userjwt=req.cookies.jwt ;


### PR DESCRIPTION
Fixes [https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/21](https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/21)

To fix the problem, we will introduce rate limiting to the route handlers using the `express-rate-limit` package. This will ensure that the number of requests to these routes is controlled, preventing potential DoS attacks.

1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the `src/routes/batch.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the routes that perform expensive operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
