### PR TITLE
Fix code scanning alert no. 35: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -66,7 +66,7 @@ exports.login = async (req, res) => {
 
   try {
     // Check if the email exists
-    const existingUser = await User.findOne({ email });
+    const existingUser = await User.findOne({ email: { $eq: email } });
 
     if (!existingUser) {
       res.send("Email not found");


### PR DESCRIPTION
Fixes [https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/35](https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/35)

To fix the problem, we need to ensure that the user input is sanitized before being used in the database query. For MongoDB, we can use the `$eq` operator to ensure that the user input is treated as a literal value. This prevents any potential NoSQL injection attacks.

**Steps to fix:**
1. Modify the query on line 69 to use the `$eq` operator.
2. Ensure that the `email` value is treated as a literal string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
