### PR TITLE
Fix code scanning alert no. 14: Missing rate limiting

### DIFF
--- a/src/routes/forgetPassword.js
+++ b/src/routes/forgetPassword.js
@@ -1,12 +1,19 @@
 const express = require('express');
 const router = express.Router();
 const forgetPasswordController=require('../controllers/forgetPasswordController');
+const rateLimit = require('express-rate-limit');
+
+// Set up rate limiter: maximum of 5 requests per minute
+const limiter = rateLimit({
+    windowMs: 1 * 60 * 1000, // 1 minute
+    max: 5 // limit each IP to 5 requests per windowMs
+});
 
 // In your routes file
 router.get('/forgetPassword', forgetPasswordController.getForgetPasswordPage);
 
 
 // In your routes file
-router.post('/forgetPassword', forgetPasswordController.postForgetPassword);
+router.post('/forgetPassword', limiter, forgetPasswordController.postForgetPassword);
 
 module.exports = router;


### PR DESCRIPTION
Fixes [https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/14](https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/14)

To fix the problem, we need to introduce rate limiting to the `postForgetPassword` route. The best way to do this is by using the `express-rate-limit` package, which allows us to easily set up rate limiting for specific routes. We will:
1. Install the `express-rate-limit` package.
2. Import and configure the rate limiter in the `src/routes/forgetPassword.js` file.
3. Apply the rate limiter to the `postForgetPassword` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
