### PR TITLE
Potential fix for code scanning alert no. 36: Database query built from user-controlled sources

### DIFF
--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -46,7 +46,10 @@ router.get('/reset-password/:token', (req, res) => {
   
     try {
       // Find the user associated with the reset token
-      const user = await User.findOne({ passwordResetToken: token, passwordResetExpires: { $gt: Date.now() } });
+      if (typeof token !== 'string') {
+        throw new Error('Invalid token format');
+      }
+      const user = await User.findOne({ passwordResetToken: { $eq: token }, passwordResetExpires: { $gt: Date.now() } });
   
       if (!user) {
         // If no user is found, redirect to the login page


### PR DESCRIPTION
Potential fix for [https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/36](https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/36)

To fix the issue, we need to ensure that the `token` value is treated as a literal and not as a query object. This can be achieved by:
1. Using the `$eq` operator in the query to explicitly compare `passwordResetToken` with the `token` value.
2. Validating the `token` to ensure it is a string before using it in the query.

This approach ensures that the query is safe from NoSQL injection attacks while maintaining the intended functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
