### PR TITLE
Potential fix for code scanning alert no. 36: Database query built from user-controlled sources

### DIFF
--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -45,8 +45,13 @@ router.get('/reset-password/:token', (req, res) => {
     const { token, password } = req.body;
   
     try {
+      // Validate the token
+      if (typeof token !== 'string') {
+        return res.status(400).json({ error: 'Invalid token format.' });
+      }
+  
       // Find the user associated with the reset token
-      const user = await User.findOne({ passwordResetToken: token, passwordResetExpires: { $gt: Date.now() } });
+      const user = await User.findOne({ passwordResetToken: { $eq: token }, passwordResetExpires: { $gt: Date.now() } });
   
       if (!user) {
         // If no user is found, redirect to the login page


### PR DESCRIPTION
Potential fix for [https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/36](https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/36)

To fix the issue, we need to ensure that the `token` value is treated as a literal value and not as a query object. This can be achieved by using MongoDB's `$eq` operator to explicitly compare the `passwordResetToken` field with the `token` value. Additionally, we should validate the `token` to ensure it is a string before using it in the query.

Steps to fix:
1. Use the `$eq` operator in the query to ensure the `token` is treated as a literal value.
2. Validate that `token` is a string before proceeding with the query. If it is not, return an error response.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
