### PR TITLE
Potential fix for code scanning alert no. 12: Uncontrolled data used in path expression

### DIFF
--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -89,14 +89,20 @@ router.post('/update-profile', jwtAuthMiddleware, upload.single('profilePicture'
       if (req.file) {
         user.img.data = fs.readFileSync(req.file.path);
         user.img.contentType = req.file.mimetype;
-        fs.unlink(req.file.path, (err) => {
-          if (err) {
-            console.log(err);
+        const resolvedPath = path.resolve(req.file.path);
+        const uploadDir = path.resolve('./uploads/');
+        if (resolvedPath.startsWith(uploadDir)) {
+          fs.unlink(resolvedPath, (err) => {
+            if (err) {
+              console.log(err);
+              return;
+            }
+            console.log('File deleted successfully!');
             return;
-          }
-          console.log('File deleted successfully!');
-          return;
-        });
+          });
+        } else {
+          console.log('Invalid file path');
+        }
       }
   
       await user.save();


### PR DESCRIPTION
Potential fix for [https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/12](https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/12)

To fix the problem, we need to ensure that the file path used in `fs.unlink` is properly validated and contained within a safe directory. We can achieve this by resolving the path and checking that it starts with the intended upload directory. This will prevent any path traversal attacks.

1. Use `path.resolve` to normalize the file path.
2. Check that the resolved path starts with the upload directory.
3. If the path is valid, proceed with `fs.unlink`; otherwise, handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
