### PR TITLE
Potential fix for code scanning alert no. 29: Missing rate limiting

### DIFF
--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -5,6 +5,7 @@ const { jwtAuthMiddleware, generateToken } = require('../middleware/jwt');
 const multer = require('multer');
 const path = require('path');
 const fs=require('fs');
+const rateLimit = require('express-rate-limit');
 
 const storage = multer.diskStorage({
     destination: './uploads/',
@@ -59,7 +60,13 @@ router.get('/form', jwtAuthMiddleware, async (req, res) => {
 
 
 
-router.post('/update-profile', jwtAuthMiddleware, upload.single('profilePicture'), async (req, res) => {
+const updateProfileLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: { error: 'Too many requests, please try again later.' },
+});
+
+router.post('/update-profile', updateProfileLimiter, jwtAuthMiddleware, upload.single('profilePicture'), async (req, res) => {
     try {
       let email;
       if (req.user.email) {


### PR DESCRIPTION
Potential fix for [https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/29](https://github.com/Priyanshukumaranand/ce_bootcamp_ejs/security/code-scanning/29)

To fix the issue, we will add rate limiting to the `/update-profile` route using the `express-rate-limit` package. This middleware will limit the number of requests a user can make to the route within a specified time window. Specifically:
1. Install the `express-rate-limit` package if it is not already installed.
2. Configure a rate limiter with appropriate settings (e.g., a maximum of 100 requests per 15 minutes).
3. Apply the rate limiter to the `/update-profile` route.

This fix ensures that the route is protected against abuse while maintaining its existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
